### PR TITLE
Add Codecov integration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+ignore:
+  - "examples/*"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,15 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Run tests in Docker
-      run: make docker-test
+    - name: Run tests with coverage in Docker
+      run: make docker-test-coverage
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./TestResults/Coverage/coverage.cobertura.xml
+        fail_ci_if_error: true
 
     - name: Build NuGet package
       if: success() && github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- enable coverage reporting with a `.codecov.yml`
- run `make docker-test-coverage` in CI
- upload Cobertura coverage to Codecov

## Testing
- `make docker-test-coverage` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844c20fd14c8327a76cdaa156fb833c