### PR TITLE
Add test for read‑only domain events

### DIFF
--- a/tests/AggregateKit.Tests/AggregateRootTests.cs
+++ b/tests/AggregateKit.Tests/AggregateRootTests.cs
@@ -32,6 +32,18 @@ namespace AggregateKit.Tests
             }
         }
 
+        private class TestEvent : DomainEventBase
+        {
+        }
+
+        private class TestAggregate : AggregateRoot<Guid>
+        {
+            public TestAggregate(Guid id) : base(id)
+            {
+                AddDomainEvent(new TestEvent());
+            }
+        }
+
         private class Article : AggregateRoot<Guid>
         {
             public string Title { get; private set; } = string.Empty;
@@ -111,5 +123,20 @@ namespace AggregateKit.Tests
             // Assert
             Assert.Empty(article.DomainEvents);
         }
+
+        [Fact]
+        public void DomainEvents_IsReadOnly()
+        {
+            // Arrange
+            var aggregate = new TestAggregate(Guid.NewGuid());
+
+            // Act
+            var events = aggregate.DomainEvents;
+            var collection = (ICollection<IDomainEvent>)events;
+
+            // Assert
+            Assert.Throws<NotSupportedException>(() => collection.Add(new TestEvent()));
+            Assert.Throws<NotSupportedException>(() => collection.Clear());
+        }
     }
-} 
+}


### PR DESCRIPTION
## Summary
- verify that `DomainEvents` collection from `AggregateRoot` is immutable
- add helper aggregate root and event for the new test

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d602709483279a18b3aa9357ee81