### PR TITLE
Add null equality check for ValueObject

### DIFF
--- a/tests/AggregateKit.Tests/ValueObjectNullTests.cs
+++ b/tests/AggregateKit.Tests/ValueObjectNullTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace AggregateKit.Tests
+{
+    public class ValueObjectNullTests
+    {
+        private class NullableVO : ValueObject
+        {
+            public string? Value { get; }
+
+            public NullableVO(string? value)
+            {
+                Value = value;
+            }
+
+            protected override IEnumerable<object?> GetEqualityComponents()
+            {
+                yield return Value;
+            }
+        }
+
+        [Fact]
+        public void ValueObjects_With_Null_Value_Are_Equal_And_GetHashCode_Does_Not_Throw()
+        {
+            // Arrange
+            var vo1 = new NullableVO(null);
+            var vo2 = new NullableVO(null);
+
+            // Act & Assert
+            Assert.Equal(vo1, vo2);
+            var hash1 = vo1.GetHashCode();
+            var hash2 = vo2.GetHashCode();
+            Assert.Equal(hash1, hash2);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ValueObjectNullTests` validating equality and hash code for nullable value components

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6844d600ad6883278040c61255ea3cdf