### PR TITLE
Add test for parameterless aggregate root constructor

### DIFF
--- a/tests/AggregateKit.Tests/AggregateRootParameterlessTests.cs
+++ b/tests/AggregateKit.Tests/AggregateRootParameterlessTests.cs
@@ -1,0 +1,24 @@
+using System;
+using Xunit;
+
+namespace AggregateKit.Tests
+{
+    public class AggregateRootParameterlessTests
+    {
+        private class ParameterlessAggregate : AggregateRoot<Guid>
+        {
+            public ParameterlessAggregate() : base() { }
+        }
+
+        [Fact]
+        public void ParameterlessConstructor_Initializes_No_DomainEvents()
+        {
+            // Act
+            var aggregate = new ParameterlessAggregate();
+
+            // Assert
+            Assert.Empty(aggregate.DomainEvents);
+            Assert.False(aggregate.HasDomainEvents);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `AggregateRootParameterlessTests` verifying aggregates created with the parameterless constructor start without domain events

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6846faeeb5388327974c53da2efcc738