### PR TITLE
Add parameterless entity test

### DIFF
--- a/tests/AggregateKit.Tests/EntityTests.cs
+++ b/tests/AggregateKit.Tests/EntityTests.cs
@@ -245,12 +245,21 @@ namespace AggregateKit.Tests
             // This test ensures the parameterless constructor works (needed for EF Core)
             // We can't directly test it since it's protected, but we can verify it exists
             // by checking that the type can be instantiated through reflection
-            
+
             var entityType = typeof(TestEntity);
             var constructors = entityType.GetConstructors(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             var parameterlessConstructor = Array.Find(constructors, c => c.GetParameters().Length == 0);
-            
+
             Assert.NotNull(parameterlessConstructor);
         }
+
+        [Fact]
+        public void Entity_ParameterlessConstructor_CanInstantiate()
+        {
+            var entity = new ParameterlessEntity();
+
+            Assert.NotNull(entity);
+            Assert.Equal(default(Guid), entity.Id);
+        }
     }
-} 
+}

--- a/tests/AggregateKit.Tests/ParameterlessEntity.cs
+++ b/tests/AggregateKit.Tests/ParameterlessEntity.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace AggregateKit.Tests
+{
+    public class ParameterlessEntity : Entity<Guid>
+    {
+        public ParameterlessEntity() : base()
+        {
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `ParameterlessEntity` class derived from `Entity<Guid>` with a public parameterless constructor
- test that an instance can be constructed with the parameterless constructor

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846faf84f1c8327857ba21b76f3d849